### PR TITLE
bucket: use external name annotation for naming the bucket

### DIFF
--- a/apis/storage/v1alpha3/types_test.go
+++ b/apis/storage/v1alpha3/types_test.go
@@ -874,7 +874,6 @@ func TestCopyBucketSpecAttrs(t *testing.T) {
 var (
 	testBucketOutputAttrs = BucketOutputAttrs{
 		Created:         metav1.NewTime(now),
-		Name:            "test-name",
 		RetentionPolicy: testRetentionPolicyStatus,
 	}
 
@@ -899,79 +898,6 @@ func TestNewBucketOutputAttrs(t *testing.T) {
 			got := NewBucketOutputAttrs(tt.args)
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewBucketOutputAttrs() = %v, want %v\n%s", got, tt.want, diff)
-			}
-		})
-	}
-}
-
-func TestBucket_GetBucketName(t *testing.T) {
-	om := metav1.ObjectMeta{
-		Namespace: "foo",
-		Name:      "bar",
-		UID:       "test-uid",
-	}
-	type fields struct {
-		ObjectMeta metav1.ObjectMeta
-		Spec       BucketSpec
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   string
-	}{
-		{
-			name: "NoNameFormat",
-			fields: fields{
-				ObjectMeta: om,
-				Spec:       BucketSpec{},
-			},
-			want: "test-uid",
-		},
-		{
-			name: "FormatString",
-			fields: fields{
-				ObjectMeta: om,
-				Spec: BucketSpec{
-					BucketParameters: BucketParameters{
-						NameFormat: "foo-%s",
-					},
-				},
-			},
-			want: "foo-test-uid",
-		},
-		{
-			name: "ConstantString",
-			fields: fields{
-				ObjectMeta: om,
-				Spec: BucketSpec{
-					BucketParameters: BucketParameters{
-						NameFormat: "foo-bar",
-					},
-				},
-			},
-			want: "foo-bar",
-		},
-		{
-			name: "InvalidMultipleSubstitutions",
-			fields: fields{
-				ObjectMeta: om,
-				Spec: BucketSpec{
-					BucketParameters: BucketParameters{
-						NameFormat: "foo-%s-bar-%s",
-					},
-				},
-			},
-			want: "foo-test-uid-bar-%!s(MISSING)",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			b := &Bucket{
-				ObjectMeta: tt.fields.ObjectMeta,
-				Spec:       tt.fields.Spec,
-			}
-			if got := b.GetBucketName(); got != tt.want {
-				t.Errorf("Bucket.GetBucketName() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/config/crd/storage.gcp.crossplane.io_bucketclasses.yaml
+++ b/config/crd/storage.gcp.crossplane.io_bucketclasses.yaml
@@ -293,11 +293,6 @@ spec:
                   description: A prefix for log object names.
                   type: string
               type: object
-            nameFormat:
-              description: NameFormat specifies the name of the external Bucket. The
-                first instance of the string '%s' will be replaced with the Kubernetes
-                UID of this Bucket.
-              type: string
             predefinedAcl:
               description: If not empty, applies a predefined set of access controls.
                 It should be set only when creating a bucket. It is always empty for

--- a/config/crd/storage.gcp.crossplane.io_buckets.yaml
+++ b/config/crd/storage.gcp.crossplane.io_buckets.yaml
@@ -376,11 +376,6 @@ spec:
                   description: A prefix for log object names.
                   type: string
               type: object
-            nameFormat:
-              description: NameFormat specifies the name of the external Bucket. The
-                first instance of the string '%s' will be replaced with the Kubernetes
-                UID of this Bucket.
-              type: string
             predefinedAcl:
               description: If not empty, applies a predefined set of access controls.
                 It should be set only when creating a bucket. It is always empty for
@@ -563,9 +558,6 @@ spec:
                 created:
                   description: Created is the creation time of the bucket.
                   format: date-time
-                  type: string
-                name:
-                  description: Name is the name of the bucket.
                   type: string
                 retentionPolicy:
                   description: "Retention policy enforces a minimum retention time

--- a/examples/storage/bucket/resource-claim.yaml
+++ b/examples/storage/bucket/resource-claim.yaml
@@ -10,6 +10,5 @@ spec:
       # containers. Uncomment one of the below if you need one of either.
       # kind: account
       # kind: container
-  name: crossplane-example-%s
   writeConnectionSecretToRef:
     name: bucket

--- a/pkg/controller/storage/bucket_operations.go
+++ b/pkg/controller/storage/bucket_operations.go
@@ -148,7 +148,7 @@ func (bh *bucketHandler) updateSecret(ctx context.Context) error {
 		s.Data[runtimev1alpha1.ResourceCredentialsSecretPasswordKey] = ss.Data[saSecretKeySecret]
 		s.Data[runtimev1alpha1.ResourceCredentialsSecretTokenKey] = ss.Data[saSecretKeyCredentials]
 	}
-	s.Data[runtimev1alpha1.ResourceCredentialsSecretEndpointKey] = []byte(bh.GetBucketName())
+	s.Data[runtimev1alpha1.ResourceCredentialsSecretEndpointKey] = []byte(meta.GetExternalName(bh))
 
 	return errors.Wrapf(apply(ctx, bh.kube, s), "failed to apply connection secret: %s/%s", s.Namespace, s.Name)
 }

--- a/pkg/controller/storage/bucket_operations_test.go
+++ b/pkg/controller/storage/bucket_operations_test.go
@@ -309,7 +309,6 @@ func Test_bucketHandler_setStatusAttrs(t *testing.T) {
 			name:   "Test",
 			fields: fields{bucket: &v1alpha3.Bucket{}},
 			args:   &storage.BucketAttrs{Name: "foo"},
-			want:   v1alpha3.BucketOutputAttrs{Name: "foo"},
 		},
 	}
 	for _, tt := range tests {
@@ -390,7 +389,6 @@ func Test_bucketHandler_updateSecret(t *testing.T) {
 	ctx := context.TODO()
 	testError := errors.New("test-error")
 	testNamespace := "test-sa-namespace"
-	bucketUID := "test-uid"
 	saSecretName := "test-sa-secret"
 	saSecretUser := "test-user"
 	saSecretPass := "test-pass"
@@ -439,7 +437,6 @@ func Test_bucketHandler_updateSecret(t *testing.T) {
 				Bucket: newBucket(testBucketName).
 					withWriteConnectionSecretToReference(testNamespace, testBucketName).
 					withServiceAccountSecretRef(testNamespace, saSecretName).
-					withUID(bucketUID).
 					Bucket,
 				kube: &test.MockClient{
 					MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
@@ -464,7 +461,7 @@ func Test_bucketHandler_updateSecret(t *testing.T) {
 								obj, &corev1.Secret{})
 						}
 						// assert secret data
-						assertSecretData(s.Data, runtimev1alpha1.ResourceCredentialsSecretEndpointKey, bucketUID)
+						assertSecretData(s.Data, runtimev1alpha1.ResourceCredentialsSecretEndpointKey, testBucketName)
 						assertSecretData(s.Data, runtimev1alpha1.ResourceCredentialsSecretUserKey, saSecretUser)
 						assertSecretData(s.Data, runtimev1alpha1.ResourceCredentialsSecretPasswordKey, saSecretPass)
 						assertSecretData(s.Data, runtimev1alpha1.ResourceCredentialsSecretTokenKey, saSecretCreds)

--- a/pkg/controller/storage/claim.go
+++ b/pkg/controller/storage/claim.go
@@ -135,11 +135,6 @@ func ConfigureBucket(_ context.Context, cm resource.Claim, cs resource.Class, mg
 		BucketParameters: rs.SpecTemplate.BucketParameters,
 	}
 
-	// Set Name bucket name if Name value is provided by Bucket Claim spec
-	if bcm.Spec.Name != "" {
-		spec.NameFormat = bcm.Spec.Name
-	}
-
 	// Set PredefinedACL from bucketClaim claim only iff: claim has this value and
 	// it is not defined in the resource class (i.e. not already in the spec)
 	if bcm.Spec.PredefinedACL != nil && spec.PredefinedACL == "" {

--- a/pkg/controller/storage/claim_test.go
+++ b/pkg/controller/storage/claim_test.go
@@ -52,7 +52,6 @@ func TestConfigureBucket(t *testing.T) {
 	namespace := "ns"
 	claimUID := types.UID("definitely-a-uuid")
 	providerName := "coolprovider"
-	bucketName := "coolbucket"
 	bucketPrivate := storagev1alpha1.ACLPrivate
 
 	cases := map[string]struct {
@@ -64,7 +63,6 @@ func TestConfigureBucket(t *testing.T) {
 				cm: &storagev1alpha1.Bucket{
 					ObjectMeta: metav1.ObjectMeta{UID: claimUID},
 					Spec: storagev1alpha1.BucketSpec{
-						Name:          bucketName,
 						PredefinedACL: &bucketPrivate,
 					},
 				},
@@ -91,7 +89,6 @@ func TestConfigureBucket(t *testing.T) {
 							ProviderReference: &corev1.ObjectReference{Name: providerName},
 						},
 						BucketParameters: v1alpha3.BucketParameters{
-							NameFormat: bucketName,
 							BucketSpecAttrs: v1alpha3.BucketSpecAttrs{
 								BucketUpdatableAttrs: v1alpha3.BucketUpdatableAttrs{
 									PredefinedACL: string(bucketPrivate),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Use external name annotation for bucket name as part of backup compatibility effort in https://github.com/crossplane/provider-gcp/issues/207

Manually tested.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.
- [x] Updated the [stack resources documentation] to include any new managed resources or classes.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-gcp/blob/master/config/stack/manifests/app.yaml
[stack resources documentation]: https://github.com/crossplane/provider-gcp/blob/master/config/stack/manifests/resources
