### PR TITLE
build: remove publishing of outputs to s3 bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ PLATFORMS ?= linux_amd64 linux_arm64
 # ====================================================================================
 # Setup Output
 
-S3_BUCKET ?= crossplane.releases
 -include build/makelib/output.mk
 
 # ====================================================================================
@@ -95,7 +94,7 @@ test-integration: $(KIND) $(KUBECTL)
 	@$(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
 	@$(OK) integration tests passed
 
-go-integration: 
+go-integration:
 	GO_TEST_FLAGS="-timeout 1h -v" GO_TAGS=integration $(MAKE) go.test.integration
 
 # Update the submodules, such as the common build scripts.

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -18,7 +18,7 @@ echo_sub_step(){
 }
 
 echo_step_completed(){
-    printf "${GRN} [✔]${NOC}" 
+    printf "${GRN} [✔]${NOC}"
 }
 
 echo_success(){
@@ -59,7 +59,7 @@ wait_for_pods_in_namespace(){
     local timeout=$1
     shift
     namespace=$1
-    shift 
+    shift
     arr=("$@")
     local counter=0
     for i in "${arr[@]}";
@@ -85,7 +85,7 @@ check_deployments(){
             exit -1
         else
             echo_step_completed
-        fi 
+        fi
 
         echo_info "check if is ready"
         IFS='/' read -ra ready_status_parts <<< "$(echo "$dep_stat" | awk ' FNR > 1 {print $2}')"
@@ -102,7 +102,7 @@ check_deployments(){
 check_pods(){
     pods=$("${KUBECTL}" -n "$1" get pods)
     echo "$pods"
-    while read -r pod_stat; do 
+    while read -r pod_stat; do
         name=$(echo "$pod_stat" | awk '{print $1}')
         echo_sub_step "inspecting pod '${name}'"
 
@@ -112,7 +112,7 @@ check_pods(){
             echo_info "is completed, foregoing further checks"
             echo_step_completed
             continue
-        fi 
+        fi
 
         echo_info "check if is ready"
         IFS='/' read -ra ready_status_parts <<< "$(echo "$pod_stat" | awk '{print $2}')"
@@ -129,7 +129,7 @@ check_pods(){
             exit -1
         else
             echo_step_completed
-        fi 
+        fi
 
         echo_info "check if has restarts"
         if (( $(echo "$pod_stat" | awk '{print $4}') > 0 )); then
@@ -150,17 +150,17 @@ eval $(make --no-print-directory -C ${projectdir} build.vars)
 
 # ------------------------------
 
-HELM_VERSION="helm-v2.10.0"
+HELM_VERSION="helm-v2.16.0"
 HOST_PLATFORM="${HOSTOS}_${HOSTARCH}"
 TOOLS_DIR="${CACHE_DIR}/tools"
 TOOLS_HOST_DIR="${TOOLS_DIR}/${HOST_PLATFORM}"
 HELM="${TOOLS_HOST_DIR}/${HELM_VERSION}"
-echo_step "installing helm ${HOSTOS}-${HOSTARCH}"
+echo_step "installing ${HELM_VERSION} ${HOSTOS}-${HOSTARCH}"
 mkdir -p ${TOOLS_HOST_DIR}/tmp-helm
 curl -fsSL https://storage.googleapis.com/kubernetes-helm/${HELM_VERSION}-${HOSTOS}-${HOSTARCH}.tar.gz | tar -xz -C ${TOOLS_HOST_DIR}/tmp-helm
 mv ${TOOLS_HOST_DIR}/tmp-helm/${HOSTOS}-${HOSTARCH}/helm ${HELM}
 rm -fr ${TOOLS_HOST_DIR}/tmp-helm
-echo_success "installing helm ${HOSTOS}-${HOSTARCH}"
+echo_success "installing ${HELM_VERSION} ${HOSTOS}-${HOSTARCH}"
 
 HOSTARCH="${HOSTARCH:-amd64}"
 BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${HOSTARCH}"
@@ -187,7 +187,6 @@ fi
 
 echo_step "creating k8s cluster using kind"
 "${KIND}" create cluster --name="${K8S_CLUSTER}"
-export KUBECONFIG="$("${KIND}" get kubeconfig-path --name="${K8S_CLUSTER}")"
 
 # tag stack image and load it to kind cluster
 docker tag "${BUILD_IMAGE}" "${STACK_IMAGE}"


### PR DESCRIPTION
The storage of outputs to s3 is not needed by provider repos.
Their important artifact is the container image which will still
be published to dockerhub.

Signed-off-by: Jared Watts <jbw976@gmail.com>

Related to https://github.com/crossplane/crossplane/issues/1320

This PR will be tested by exercising the build process in CI on Jenkins.  Previous PRs have been publishing their output to s3, so we will verify that s3 does not get any output published to it from this PR.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.
- [x] Updated the [stack resources documentation] to include any new managed resources or classes.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-gcp/blob/master/config/stack/manifests/app.yaml
[stack resources documentation]: https://github.com/crossplane/provider-gcp/blob/master/config/stack/manifests/resources
