### PR TITLE
Ignore ForceSendFields when checking IsUpToDate

### DIFF
--- a/pkg/clients/cluster/cluster.go
+++ b/pkg/clients/cluster/cluster.go
@@ -1071,7 +1071,13 @@ func IsUpToDate(name string, in *v1beta1.GKEClusterParameters, observed *contain
 	if checkForBootstrapNodePool(observed) {
 		return false, deleteBootstrapNodePoolFn(), nil
 	}
-	if !cmp.Equal(desired.AddonsConfig, observed.AddonsConfig, cmpopts.EquateEmpty()) {
+	if !cmp.Equal(desired.AddonsConfig, observed.AddonsConfig, cmpopts.EquateEmpty(),
+		cmpopts.IgnoreFields(container.AddonsConfig{}, "CloudRunConfig.ForceSendFields"),
+		cmpopts.IgnoreFields(container.AddonsConfig{}, "HorizontalPodAutoscaling.ForceSendFields"),
+		cmpopts.IgnoreFields(container.AddonsConfig{}, "HttpLoadBalancing.ForceSendFields"),
+		cmpopts.IgnoreFields(container.AddonsConfig{}, "IstioConfig.ForceSendFields"),
+		cmpopts.IgnoreFields(container.AddonsConfig{}, "KubernetesDashboard.ForceSendFields"),
+		cmpopts.IgnoreFields(container.AddonsConfig{}, "NetworkPolicyConfig.ForceSendFields")) {
 		return false, newAddonsConfigUpdateFn(in.AddonsConfig), nil
 	}
 	if !cmp.Equal(desired.Autoscaling, observed.Autoscaling, cmpopts.EquateEmpty()) {

--- a/pkg/clients/cluster/cluster_test.go
+++ b/pkg/clients/cluster/cluster_test.go
@@ -1460,6 +1460,29 @@ func TestIsUpToDate(t *testing.T) {
 				isErr:    false,
 			},
 		},
+		"UpToDateIgnoreForceSendFields": {
+			args: args{
+				name: name,
+				cluster: cluster(func(c *container.Cluster) {
+					c.AddonsConfig = &container.AddonsConfig{
+						KubernetesDashboard: &container.KubernetesDashboard{
+							Disabled: true,
+						},
+					}
+				}),
+				params: params(func(p *v1beta1.GKEClusterParameters) {
+					p.AddonsConfig = &v1beta1.AddonsConfig{
+						KubernetesDashboard: &v1beta1.KubernetesDashboard{
+							Disabled: gcp.BoolPtr(true),
+						},
+					}
+				}),
+			},
+			want: want{
+				upToDate: true,
+				isErr:    false,
+			},
+		},
 		"NeedsUpdate": {
 			args: args{
 				name: name,


### PR DESCRIPTION


Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

We set ForceSendFields when we want to issue an update that includes a zero-value. However, when comparing to check if an object is up to date with its external representation, we do not want to check the ForceSendFields field in the diff.

Note: this bug does not actually degrade performance of GKE clusters, it just hits the GCP API with a bunch of no-op updates.

I tested with the following class and claim to make sure that resources reached a stable state and did not continually issue updates:

```
apiVersion: container.gcp.crossplane.io/v1beta1
kind: GKEClusterClass
metadata:
  labels:
    cool: label
  name: cool-cluster
specTemplate:
  forProvider:
    description: A cool cluster
    addonsConfig:
      cloudRunConfig:
        disabled: false
    initialClusterVersion: 1.15.9-gke.26
    ipAllocationPolicy:
      createSubnetwork: true
      useIpAliases: true
    location: us-central1
    masterAuth:
      username: admin
    networkPolicy:
      enabled: true
    network: default
    podSecurityPolicyConfig:
      enabled: false
    verticalPodAutoscaling:
      enabled: true
  providerRef:
    name: gcp-provider
  reclaimPolicy: Delete
  writeConnectionSecretsToNamespace: crossplane-system
---
apiVersion: compute.crossplane.io/v1alpha1
kind: KubernetesCluster
metadata:
  name: cool
spec:
  classSelector:
    matchLabels:
      cool: label
  writeConnectionSecretToRef:
    name: cool
```

I also tested without any addons enabled, which is the scenario in which this bug was identified.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.
- [ ] Updated the [stack resources documentation] to include any new managed resources or classes.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-gcp/blob/master/config/stack/manifests/app.yaml
[stack resources documentation]: https://github.com/crossplane/provider-gcp/blob/master/config/stack/manifests/resources
