### PR TITLE
Raw cluster name in spec is too long for printer column

### DIFF
--- a/apis/container/v1alpha1/nodepool_types.go
+++ b/apis/container/v1alpha1/nodepool_types.go
@@ -568,7 +568,7 @@ type NodePoolStatus struct {
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.atProvider.status"
-// +kubebuilder:printcolumn:name="CLUSTER-NAME",type="string",JSONPath=".spec.forProvider.cluster"
+// +kubebuilder:printcolumn:name="CLUSTER-REF",type="string",JSONPath=".spec.forProvider.clusterRef.name"
 // +kubebuilder:printcolumn:name="NODE-POOL-CLASS",type="string",JSONPath=".spec.classRef.name"
 // +kubebuilder:printcolumn:name="RECLAIM-POLICY",type="string",JSONPath=".spec.reclaimPolicy"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"

--- a/config/crd/container.gcp.crossplane.io_nodepools.yaml
+++ b/config/crd/container.gcp.crossplane.io_nodepools.yaml
@@ -18,8 +18,8 @@ spec:
   - JSONPath: .status.atProvider.status
     name: STATE
     type: string
-  - JSONPath: .spec.forProvider.cluster
-    name: CLUSTER-NAME
+  - JSONPath: .spec.forProvider.clusterRef.name
+    name: CLUSTER-REF
     type: string
   - JSONPath: .spec.classRef.name
     name: NODE-POOL-CLASS


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

While testing, I realized the raw cluster name is too long for a printer column and it messes up the layout. I believe in most of the cases, the cluster is referenced, so, using the name of `container.GKECluster` CR that is referenced could be nicer.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.
- [x] Updated the [package resources documentation] to include any new managed resources or classes.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-gcp/blob/master/config/stack/manifests/app.yaml
[package resources documentation]: https://github.com/crossplane/provider-gcp/blob/master/config/package/manifests/resources
