### PR TITLE
Clean up crds.clean output on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,8 @@ cobertura:
 
 crds.clean:
 	@$(INFO) cleaning generated CRDs
-	@find package/crds -name *.yaml -exec sed -i '.sed' -e '1,2d' {} \;
-	@find package/crds -name *.yaml.sed -delete
+	@find package/crds -name *.yaml -exec sed -i.sed -e '1,2d' {} \; || $(FAIL)
+	@find package/crds -name *.yaml.sed -delete || $(FAIL)
 	@$(OK) cleaned generated CRDs
 
 generate: crds.clean


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The crds.clean syntax seems to work correctly but emits a warning that
it cannot read the file when running on linux. This updates to a replace
format that is compatible with both linux and darwin systems.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

See `check-diff` logs [here](https://jenkinsci.upbound.io/blue/organizations/jenkins/crossplane%2Fprovider-gcp-pipelines%2Fprovider-gcp/detail/master/151/pipeline/29) for example.

Follow-up to #258 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Ran `make generate` on both mac and ubuntu system.

[contribution process]: https://git.io/fj2m9
