### PR TITLE
Remove printer columns for unused fields

### DIFF
--- a/apis/container/v1alpha1/nodepool_types.go
+++ b/apis/container/v1alpha1/nodepool_types.go
@@ -571,8 +571,6 @@ type NodePoolStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.atProvider.status"
 // +kubebuilder:printcolumn:name="CLUSTER-REF",type="string",JSONPath=".spec.forProvider.clusterRef.name"
-// +kubebuilder:printcolumn:name="NODE-POOL-CLASS",type="string",JSONPath=".spec.classRef.name"
-// +kubebuilder:printcolumn:name="RECLAIM-POLICY",type="string",JSONPath=".spec.reclaimPolicy"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,gcp}
 type NodePool struct {

--- a/apis/container/v1beta1/gkecluster_types.go
+++ b/apis/container/v1beta1/gkecluster_types.go
@@ -1628,7 +1628,6 @@ type GKEClusterStatus struct {
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.atProvider.status"
 // +kubebuilder:printcolumn:name="ENDPOINT",type="string",JSONPath=".status.atProvider.endpoint"
 // +kubebuilder:printcolumn:name="LOCATION",type="string",JSONPath=".spec.forProvider.location"
-// +kubebuilder:printcolumn:name="RECLAIM-POLICY",type="string",JSONPath=".spec.reclaimPolicy"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,gcp}
 type GKECluster struct {

--- a/apis/storage/v1alpha3/types.go
+++ b/apis/storage/v1alpha3/types.go
@@ -808,7 +808,6 @@ type BucketStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="STORAGE_CLASS",type="string",JSONPath=".spec.storageClass"
 // +kubebuilder:printcolumn:name="LOCATION",type="string",JSONPath=".spec.location"
-// +kubebuilder:printcolumn:name="RECLAIM_POLICY",type="string",JSONPath=".spec.reclaimPolicy"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,gcp}
 type Bucket struct {

--- a/package/crds/container.gcp.crossplane.io_gkeclusters.yaml
+++ b/package/crds/container.gcp.crossplane.io_gkeclusters.yaml
@@ -22,9 +22,6 @@ spec:
   - JSONPath: .spec.forProvider.location
     name: LOCATION
     type: string
-  - JSONPath: .spec.reclaimPolicy
-    name: RECLAIM-POLICY
-    type: string
   - JSONPath: .metadata.creationTimestamp
     name: AGE
     type: date

--- a/package/crds/container.gcp.crossplane.io_nodepools.yaml
+++ b/package/crds/container.gcp.crossplane.io_nodepools.yaml
@@ -19,12 +19,6 @@ spec:
   - JSONPath: .spec.forProvider.clusterRef.name
     name: CLUSTER-REF
     type: string
-  - JSONPath: .spec.classRef.name
-    name: NODE-POOL-CLASS
-    type: string
-  - JSONPath: .spec.reclaimPolicy
-    name: RECLAIM-POLICY
-    type: string
   - JSONPath: .metadata.creationTimestamp
     name: AGE
     type: date

--- a/package/crds/storage.gcp.crossplane.io_buckets.yaml
+++ b/package/crds/storage.gcp.crossplane.io_buckets.yaml
@@ -19,9 +19,6 @@ spec:
   - JSONPath: .spec.location
     name: LOCATION
     type: string
-  - JSONPath: .spec.reclaimPolicy
-    name: RECLAIM_POLICY
-    type: string
   - JSONPath: .metadata.creationTimestamp
     name: AGE
     type: date


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Reclaim policy and resource classes have been removed so printer columns
for them will never be populated. This removes any printer columns that
use these fields.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

xref https://github.com/crossplane/crossplane/issues/1781

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make generate`

[contribution process]: https://git.io/fj2m9
