### PR TITLE
Allow buckets to use a default providerConfigRef

### DIFF
--- a/pkg/controller/storage/managed.go
+++ b/pkg/controller/storage/managed.go
@@ -59,7 +59,6 @@ func SetupBucket(mgr ctrl.Manager, l logging.Logger) error {
 			resource.ManagedKind(v1alpha3.BucketGroupVersionKind),
 			managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}),
 			managed.WithLogger(l.WithValues("controller", name)),
-			managed.WithInitializers(managed.NewNameAsExternalName(mgr.GetClient())),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
The default initializers set the external name and also the default provider config ref. The bucket controller was explicitly using only the former.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
