### PR TITLE
Fix incomplete reference resolution of service account member

### DIFF
--- a/apis/iam/v1alpha1/referencers.go
+++ b/apis/iam/v1alpha1/referencers.go
@@ -44,6 +44,9 @@ func ServiceAccountMemberName() reference.ExtractValueFn {
 		if !ok {
 			return ""
 		}
+		if n.Status.AtProvider.Email == "" {
+			return ""
+		}
 		return fmt.Sprintf("serviceAccount:%s", n.Status.AtProvider.Email)
 	}
 }

--- a/apis/kms/v1alpha1/referencers.go
+++ b/apis/kms/v1alpha1/referencers.go
@@ -18,15 +18,14 @@ package v1alpha1
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/crossplane/provider-gcp/apis/iam/v1alpha1"
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/reference"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
+
+	iamv1alpha1 "github.com/crossplane/provider-gcp/apis/iam/v1alpha1"
 )
 
 // KeyRingRRN extracts the partially qualified URL of a Network.
@@ -73,20 +72,6 @@ func CryptoKeyRRN() reference.ExtractValueFn {
 	}
 }
 
-// ServiceAccountMemberName returns member name for a given ServiceAccount Object.
-func ServiceAccountMemberName() reference.ExtractValueFn {
-	return func(mg resource.Managed) string {
-		n, ok := mg.(*v1alpha1.ServiceAccount)
-		if !ok {
-			return ""
-		}
-		if n.Status.AtProvider.Email == "" {
-			return ""
-		}
-		return fmt.Sprintf("serviceAccount:%s", n.Status.AtProvider.Email)
-	}
-}
-
 // ResolveReferences of this CryptoKeyPolicy
 func (in *CryptoKeyPolicy) ResolveReferences(ctx context.Context, c client.Reader) error {
 	r := reference.NewAPIResolver(c, in)
@@ -111,8 +96,8 @@ func (in *CryptoKeyPolicy) ResolveReferences(ctx context.Context, c client.Reade
 			CurrentValues: in.Spec.ForProvider.Policy.Bindings[i].Members,
 			References:    in.Spec.ForProvider.Policy.Bindings[i].ServiceAccountMemberRefs,
 			Selector:      in.Spec.ForProvider.Policy.Bindings[i].ServiceAccountMemberSelector,
-			To:            reference.To{Managed: &v1alpha1.ServiceAccount{}, List: &v1alpha1.ServiceAccountList{}},
-			Extract:       ServiceAccountMemberName(),
+			To:            reference.To{Managed: &iamv1alpha1.ServiceAccount{}, List: &iamv1alpha1.ServiceAccountList{}},
+			Extract:       iamv1alpha1.ServiceAccountMemberName(),
 		})
 		if err != nil {
 			return errors.Wrapf(err, "spec.forProvider.Policy.Bindings[%d].Members", i)

--- a/apis/kms/v1alpha1/referencers.go
+++ b/apis/kms/v1alpha1/referencers.go
@@ -80,6 +80,9 @@ func ServiceAccountMemberName() reference.ExtractValueFn {
 		if !ok {
 			return ""
 		}
+		if n.Status.AtProvider.Email == "" {
+			return ""
+		}
 		return fmt.Sprintf("serviceAccount:%s", n.Status.AtProvider.Email)
 	}
 }

--- a/apis/storage/v1alpha1/referencers.go
+++ b/apis/storage/v1alpha1/referencers.go
@@ -18,30 +18,14 @@ package v1alpha1
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/crossplane/crossplane-runtime/pkg/reference"
-	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/crossplane/provider-gcp/apis/iam/v1alpha1"
+	iamv1alpha1 "github.com/crossplane/provider-gcp/apis/iam/v1alpha1"
 	"github.com/crossplane/provider-gcp/apis/storage/v1alpha3"
 )
-
-// ServiceAccountMemberName returns member name for a given ServiceAccount Object.
-func ServiceAccountMemberName() reference.ExtractValueFn {
-	return func(mg resource.Managed) string {
-		n, ok := mg.(*v1alpha1.ServiceAccount)
-		if !ok {
-			return ""
-		}
-		if n.Status.AtProvider.Email == "" {
-			return ""
-		}
-		return fmt.Sprintf("serviceAccount:%s", n.Status.AtProvider.Email)
-	}
-}
 
 // ResolveReferences of this BucketPolicy
 func (in *BucketPolicy) ResolveReferences(ctx context.Context, c client.Reader) error {
@@ -67,8 +51,8 @@ func (in *BucketPolicy) ResolveReferences(ctx context.Context, c client.Reader) 
 			CurrentValues: in.Spec.ForProvider.Policy.Bindings[i].Members,
 			References:    in.Spec.ForProvider.Policy.Bindings[i].ServiceAccountMemberRefs,
 			Selector:      in.Spec.ForProvider.Policy.Bindings[i].ServiceAccountMemberSelector,
-			To:            reference.To{Managed: &v1alpha1.ServiceAccount{}, List: &v1alpha1.ServiceAccountList{}},
-			Extract:       ServiceAccountMemberName(),
+			To:            reference.To{Managed: &iamv1alpha1.ServiceAccount{}, List: &iamv1alpha1.ServiceAccountList{}},
+			Extract:       iamv1alpha1.ServiceAccountMemberName(),
 		})
 		if err != nil {
 			return errors.Wrapf(err, "spec.forProvider.Policy.Bindings[%d].Members", i)
@@ -103,8 +87,8 @@ func (in *BucketPolicyMember) ResolveReferences(ctx context.Context, c client.Re
 		CurrentValue: reference.FromPtrValue(in.Spec.ForProvider.Member),
 		Reference:    in.Spec.ForProvider.ServiceAccountMemberRef,
 		Selector:     in.Spec.ForProvider.ServiceAccountMemberSelector,
-		To:           reference.To{Managed: &v1alpha1.ServiceAccount{}, List: &v1alpha1.ServiceAccountList{}},
-		Extract:      ServiceAccountMemberName(),
+		To:           reference.To{Managed: &iamv1alpha1.ServiceAccount{}, List: &iamv1alpha1.ServiceAccountList{}},
+		Extract:      iamv1alpha1.ServiceAccountMemberName(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "spec.forProvider.member")

--- a/apis/storage/v1alpha1/referencers.go
+++ b/apis/storage/v1alpha1/referencers.go
@@ -36,6 +36,9 @@ func ServiceAccountMemberName() reference.ExtractValueFn {
 		if !ok {
 			return ""
 		}
+		if n.Status.AtProvider.Email == "" {
+			return ""
+		}
 		return fmt.Sprintf("serviceAccount:%s", n.Status.AtProvider.Email)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Hasan Turken <turkenh@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Reference to member field referenced via ServiceAccount object gets resolved before ServiceAccount being created and properly reporting `status.atProvider.email`. This PR fixes this by preventing reference being resolved beforehand.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Via a composition including a service account and a policy resource referencing to that service account. This way, we ended up both CRs being created together and observed the issue being fixed with this PR. Verified the fix prevents incomplete reference resolution.

[contribution process]: https://git.io/fj2m9
