### PR TITLE
Update all controllers to use default managed rate limiter

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 
 	"github.com/crossplane/provider-gcp/apis"
 	"github.com/crossplane/provider-gcp/pkg/controller"
@@ -61,6 +62,6 @@ func main() {
 	kingpin.FatalIfError(err, "Cannot create controller manager")
 
 	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add GCP APIs to scheme")
-	kingpin.FatalIfError(controller.Setup(mgr, log), "Cannot setup GCP controllers")
+	kingpin.FatalIfError(controller.Setup(mgr, log, ratelimiter.NewDefaultProviderRateLimiter(ratelimiter.DefaultProviderRPS)), "Cannot setup GCP controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	cloud.google.com/go v0.57.0
 	cloud.google.com/go/pubsub v1.3.1
 	cloud.google.com/go/storage v1.6.0
-	github.com/crossplane/crossplane-runtime v0.12.1-0.20210201221909-45bc6d50351e
+	github.com/crossplane/crossplane-runtime v0.12.1-0.20210219155338-30a941c3c3c6
 	github.com/crossplane/crossplane-tools v0.0.0-20201201125637-9ddc70edfd0d
 	github.com/google/go-cmp v0.5.2
 	github.com/googleapis/gax-go v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.12.1-0.20210201221909-45bc6d50351e h1:HFWAGyWLEEHE1754R/1IoUwTy074lR5YNiyVpkY58r4=
-github.com/crossplane/crossplane-runtime v0.12.1-0.20210201221909-45bc6d50351e/go.mod h1:hrSGAVcwk4FVoYhSPlLcM1W5uFLIYxpxGmkoNddI8rs=
+github.com/crossplane/crossplane-runtime v0.12.1-0.20210219155338-30a941c3c3c6 h1:Rpmbk1dM9246FjTwV7qvbYlIR86UyznQSp8Pl8RtxU8=
+github.com/crossplane/crossplane-runtime v0.12.1-0.20210219155338-30a941c3c3c6/go.mod h1:Bc54/KBvV9ld/tvervcnhcSzk13FYguTqmYt72Mybps=
 github.com/crossplane/crossplane-tools v0.0.0-20201201125637-9ddc70edfd0d h1:QiCkTnlBf7OuQF3SJF3yGqS5SQuPOFPrs0pIRAsY7QY=
 github.com/crossplane/crossplane-tools v0.0.0-20201201125637-9ddc70edfd0d/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=

--- a/pkg/controller/cache/managed.go
+++ b/pkg/controller/cache/managed.go
@@ -23,12 +23,15 @@ import (
 	redisv1 "cloud.google.com/go/redis/apiv1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -51,11 +54,14 @@ const (
 
 // SetupCloudMemorystoreInstance adds a controller that reconciles
 // CloudMemorystoreInstances.
-func SetupCloudMemorystoreInstance(mgr ctrl.Manager, l logging.Logger) error {
+func SetupCloudMemorystoreInstance(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1beta1.CloudMemorystoreInstanceGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1beta1.CloudMemorystoreInstance{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.CloudMemorystoreInstanceGroupVersionKind),

--- a/pkg/controller/compute/globaladdress.go
+++ b/pkg/controller/compute/globaladdress.go
@@ -22,13 +22,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"google.golang.org/api/compute/v1"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -48,11 +51,14 @@ const (
 
 // SetupGlobalAddress adds a controller that reconciles
 // GlobalAddress managed resources.
-func SetupGlobalAddress(mgr ctrl.Manager, l logging.Logger) error {
+func SetupGlobalAddress(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1beta1.GlobalAddressGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1beta1.GlobalAddress{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.GlobalAddressGroupVersionKind),

--- a/pkg/controller/compute/network.go
+++ b/pkg/controller/compute/network.go
@@ -22,13 +22,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	compute "google.golang.org/api/compute/v1"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -52,11 +55,14 @@ const (
 
 // SetupNetwork adds a controller that reconciles Network managed
 // resources.
-func SetupNetwork(mgr ctrl.Manager, l logging.Logger) error {
+func SetupNetwork(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1beta1.NetworkGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1beta1.Network{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.NetworkGroupVersionKind),

--- a/pkg/controller/compute/subnetwork.go
+++ b/pkg/controller/compute/subnetwork.go
@@ -22,13 +22,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	googlecompute "google.golang.org/api/compute/v1"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -52,11 +55,14 @@ const (
 
 // SetupSubnetwork adds a controller that reconciles Subnetwork
 // managed resources.
-func SetupSubnetwork(mgr ctrl.Manager, l logging.Logger) error {
+func SetupSubnetwork(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1beta1.SubnetworkGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1beta1.Subnetwork{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.SubnetworkGroupVersionKind),

--- a/pkg/controller/container/nodepool.go
+++ b/pkg/controller/container/nodepool.go
@@ -22,13 +22,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	container "google.golang.org/api/container/v1beta1"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -50,11 +53,14 @@ const (
 
 // SetupNodePool adds a controller that reconciles NodePool managed
 // resources.
-func SetupNodePool(mgr ctrl.Manager, l logging.Logger) error {
+func SetupNodePool(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1alpha1.NodePoolGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1alpha1.NodePool{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.NodePoolGroupVersionKind),

--- a/pkg/controller/database/cloudsql.go
+++ b/pkg/controller/database/cloudsql.go
@@ -23,14 +23,17 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/password"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -55,7 +58,7 @@ const (
 
 // SetupCloudSQLInstance adds a controller that reconciles
 // CloudSQLInstance managed resources.
-func SetupCloudSQLInstance(mgr ctrl.Manager, l logging.Logger) error {
+func SetupCloudSQLInstance(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1beta1.CloudSQLInstanceGroupKind)
 
 	r := managed.NewReconciler(mgr,
@@ -68,6 +71,9 @@ func SetupCloudSQLInstance(mgr ctrl.Manager, l logging.Logger) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1beta1.CloudSQLInstance{}).
 		Complete(r)
 }

--- a/pkg/controller/gcp.go
+++ b/pkg/controller/gcp.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -35,8 +36,8 @@ import (
 
 // Setup creates all GCP controllers with the supplied logger and adds them to
 // the supplied manager.
-func Setup(mgr ctrl.Manager, l logging.Logger) error {
-	for _, setup := range []func(ctrl.Manager, logging.Logger) error{
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter) error{
 		config.Setup,
 		cache.SetupCloudMemorystoreInstance,
 		compute.SetupGlobalAddress,
@@ -56,7 +57,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger) error {
 		storage.SetupBucketPolicy,
 		storage.SetupBucketPolicyMember,
 	} {
-		if err := setup(mgr, l); err != nil {
+		if err := setup(mgr, l, rl); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/iam/serviceaccount.go
+++ b/pkg/controller/iam/serviceaccount.go
@@ -22,13 +22,16 @@ import (
 
 	"github.com/pkg/errors"
 	iamv1 "google.golang.org/api/iam/v1"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -48,11 +51,14 @@ const (
 )
 
 // SetupServiceAccount adds a controller that reconciles ServiceAccounts.
-func SetupServiceAccount(mgr ctrl.Manager, l logging.Logger) error {
+func SetupServiceAccount(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1alpha1.ServiceAccountGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1alpha1.ServiceAccount{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.ServiceAccountGroupVersionKind),

--- a/pkg/controller/iam/serviceaccountpolicy.go
+++ b/pkg/controller/iam/serviceaccountpolicy.go
@@ -21,12 +21,15 @@ import (
 
 	"github.com/pkg/errors"
 	iamv1 "google.golang.org/api/iam/v1"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -44,11 +47,14 @@ const (
 )
 
 // SetupServiceAccountPolicy adds a controller that reconciles ServiceAccountPolicys.
-func SetupServiceAccountPolicy(mgr ctrl.Manager, l logging.Logger) error {
+func SetupServiceAccountPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1alpha1.ServiceAccountPolicyGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1alpha1.ServiceAccountPolicy{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.ServiceAccountPolicyGroupVersionKind),

--- a/pkg/controller/kms/cryptokey.go
+++ b/pkg/controller/kms/cryptokey.go
@@ -23,13 +23,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	kmsv1 "google.golang.org/api/cloudkms/v1"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -44,11 +47,14 @@ const (
 )
 
 // SetupCryptoKey adds a controller that reconciles CryptoKeys.
-func SetupCryptoKey(mgr ctrl.Manager, l logging.Logger) error {
+func SetupCryptoKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1alpha1.CryptoKeyGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1alpha1.CryptoKey{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.CryptoKeyGroupVersionKind),

--- a/pkg/controller/kms/cryptokeypolicy.go
+++ b/pkg/controller/kms/cryptokeypolicy.go
@@ -21,12 +21,15 @@ import (
 
 	"github.com/pkg/errors"
 	kmsv1 "google.golang.org/api/cloudkms/v1"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -43,11 +46,14 @@ const (
 )
 
 // SetupCryptoKeyPolicy adds a controller that reconciles CryptoKeyPolicys.
-func SetupCryptoKeyPolicy(mgr ctrl.Manager, l logging.Logger) error {
+func SetupCryptoKeyPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1alpha1.CryptoKeyPolicyGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1alpha1.CryptoKeyPolicy{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.CryptoKeyPolicyGroupVersionKind),

--- a/pkg/controller/kms/keyring.go
+++ b/pkg/controller/kms/keyring.go
@@ -22,13 +22,16 @@ import (
 
 	"github.com/pkg/errors"
 	kmsv1 "google.golang.org/api/cloudkms/v1"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -47,11 +50,14 @@ const (
 )
 
 // SetupKeyRing adds a controller that reconciles KeyRings.
-func SetupKeyRing(mgr ctrl.Manager, l logging.Logger) error {
+func SetupKeyRing(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1alpha1.KeyRingGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1alpha1.KeyRing{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.KeyRingGroupVersionKind),

--- a/pkg/controller/pubsub/topic.go
+++ b/pkg/controller/pubsub/topic.go
@@ -24,13 +24,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	pubsubpb "google.golang.org/genproto/googleapis/pubsub/v1"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -50,11 +53,14 @@ const (
 )
 
 // SetupTopic adds a controller that reconciles Topics.
-func SetupTopic(mgr ctrl.Manager, l logging.Logger) error {
+func SetupTopic(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1alpha1.TopicGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1alpha1.Topic{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.TopicGroupVersionKind),

--- a/pkg/controller/servicenetworking/connection.go
+++ b/pkg/controller/servicenetworking/connection.go
@@ -24,12 +24,15 @@ import (
 	"github.com/pkg/errors"
 	compute "google.golang.org/api/compute/v1"
 	servicenetworking "google.golang.org/api/servicenetworking/v1"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -71,10 +74,13 @@ const (
 
 // SetupConnection adds a controller that reconciles Connection
 // managed resources.
-func SetupConnection(mgr ctrl.Manager, l logging.Logger) error {
+func SetupConnection(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1beta1.ConnectionGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1beta1.Connection{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.ConnectionGroupVersionKind),

--- a/pkg/controller/storage/bucket.go
+++ b/pkg/controller/storage/bucket.go
@@ -23,13 +23,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -49,11 +52,14 @@ const (
 )
 
 // SetupBucket adds a controller that reconciles Buckets.
-func SetupBucket(mgr ctrl.Manager, l logging.Logger) error {
+func SetupBucket(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1alpha3.BucketGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1alpha3.Bucket{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha3.BucketGroupVersionKind),

--- a/pkg/controller/storage/bucketpolicymember.go
+++ b/pkg/controller/storage/bucketpolicymember.go
@@ -21,12 +21,15 @@ import (
 
 	"github.com/pkg/errors"
 	"google.golang.org/api/storage/v1"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -41,11 +44,14 @@ const (
 )
 
 // SetupBucketPolicyMember adds a controller that reconciles BucketPolicyMembers.
-func SetupBucketPolicyMember(mgr ctrl.Manager, l logging.Logger) error {
+func SetupBucketPolicyMember(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName(v1alpha1.BucketPolicyMemberGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		}).
 		For(&v1alpha1.BucketPolicyMember{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.BucketPolicyMemberGroupVersionKind),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates all controllers to use updated managed reconciler and a max of
rate limiter that accepts the provider-level token bucket limiter and a
per-item exponential backoff limiter with base delay of 1s and max delay
of 60s.

Same as https://github.com/crossplane/provider-aws/pull/544

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

![gcp-backoff](https://user-images.githubusercontent.com/31777345/108781503-8fb74f00-752f-11eb-9509-86fbff00b69e.png)


[contribution process]: https://git.io/fj2m9
