### PR TITLE
Add global poll interval flag

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -35,7 +35,8 @@ func main() {
 	var (
 		app            = kingpin.New(filepath.Base(os.Args[0]), "GCP support for Crossplane.").DefaultEnvars()
 		debug          = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
-		syncPeriod     = app.Flag("sync", "Controller manager sync period such as 300ms, 1.5h, or 2h45m").Short('s').Default("1h").Duration()
+		syncInterval   = app.Flag("sync", "Sync interval controls how often all resources will be double checked for drift.").Short('s').Default("1h").Duration()
+		pollInterval   = app.Flag("poll", "Poll interval controls how often an individual resource should be checked for drift.").Default("1m").Duration()
 		leaderElection = app.Flag("leader-election", "Use leader election for the conroller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
@@ -49,7 +50,7 @@ func main() {
 		ctrl.SetLogger(zl)
 	}
 
-	log.Debug("Starting", "sync-period", syncPeriod.String())
+	log.Debug("Starting", "sync-period", syncInterval.String())
 
 	cfg, err := ctrl.GetConfig()
 	kingpin.FatalIfError(err, "Cannot get API server rest config")
@@ -57,11 +58,11 @@ func main() {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:   *leaderElection,
 		LeaderElectionID: "crossplane-leader-election-provider-gcp",
-		SyncPeriod:       syncPeriod,
+		SyncPeriod:       syncInterval,
 	})
 	kingpin.FatalIfError(err, "Cannot create controller manager")
 
 	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add GCP APIs to scheme")
-	kingpin.FatalIfError(controller.Setup(mgr, log, ratelimiter.NewDefaultProviderRateLimiter(ratelimiter.DefaultProviderRPS)), "Cannot setup GCP controllers")
+	kingpin.FatalIfError(controller.Setup(mgr, log, ratelimiter.NewDefaultProviderRateLimiter(ratelimiter.DefaultProviderRPS), *pollInterval), "Cannot setup GCP controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }

--- a/pkg/controller/cache/managed.go
+++ b/pkg/controller/cache/managed.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -57,7 +58,7 @@ const (
 
 // SetupCloudMemorystoreInstance adds a controller that reconciles
 // CloudMemorystoreInstances.
-func SetupCloudMemorystoreInstance(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupCloudMemorystoreInstance(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.CloudMemorystoreInstanceGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -69,6 +70,7 @@ func SetupCloudMemorystoreInstance(mgr ctrl.Manager, l logging.Logger, rl workqu
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.CloudMemorystoreInstanceGroupVersionKind),
 			managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/compute/globaladdress.go
+++ b/pkg/controller/compute/globaladdress.go
@@ -18,6 +18,7 @@ package compute
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -51,7 +52,7 @@ const (
 
 // SetupGlobalAddress adds a controller that reconciles
 // GlobalAddress managed resources.
-func SetupGlobalAddress(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupGlobalAddress(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.GlobalAddressGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -65,6 +66,7 @@ func SetupGlobalAddress(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLim
 			managed.WithExternalConnecter(&gaConnector{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/compute/network.go
+++ b/pkg/controller/compute/network.go
@@ -18,6 +18,7 @@ package compute
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -55,7 +56,7 @@ const (
 
 // SetupNetwork adds a controller that reconciles Network managed
 // resources.
-func SetupNetwork(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupNetwork(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.NetworkGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -69,6 +70,7 @@ func SetupNetwork(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) 
 			managed.WithExternalConnecter(&networkConnector{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/compute/subnetwork.go
+++ b/pkg/controller/compute/subnetwork.go
@@ -18,6 +18,7 @@ package compute
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -55,7 +56,7 @@ const (
 
 // SetupSubnetwork adds a controller that reconciles Subnetwork
 // managed resources.
-func SetupSubnetwork(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupSubnetwork(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.SubnetworkGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -69,6 +70,7 @@ func SetupSubnetwork(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 			managed.WithExternalConnecter(&subnetworkConnector{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/container/cluster.go
+++ b/pkg/controller/container/cluster.go
@@ -18,6 +18,7 @@ package container
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -55,7 +56,7 @@ const (
 
 // SetupCluster adds a controller that reconciles Cluster
 // managed resources.
-func SetupCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta2.ClusterGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -68,6 +69,7 @@ func SetupCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) 
 			resource.ManagedKind(v1beta2.ClusterGroupVersionKind),
 			managed.WithExternalConnecter(&clusterConnector{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/container/nodepool.go
+++ b/pkg/controller/container/nodepool.go
@@ -18,6 +18,7 @@ package container
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -53,7 +54,7 @@ const (
 
 // SetupNodePool adds a controller that reconciles NodePool managed
 // resources.
-func SetupNodePool(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupNodePool(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.NodePoolGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -66,6 +67,7 @@ func SetupNodePool(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter)
 			resource.ManagedKind(v1beta1.NodePoolGroupVersionKind),
 			managed.WithExternalConnecter(&nodePoolConnector{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/database/cloudsql.go
+++ b/pkg/controller/database/cloudsql.go
@@ -19,6 +19,7 @@ package database
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -58,7 +59,7 @@ const (
 
 // SetupCloudSQLInstance adds a controller that reconciles
 // CloudSQLInstance managed resources.
-func SetupCloudSQLInstance(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupCloudSQLInstance(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.CloudSQLInstanceGroupKind)
 
 	r := managed.NewReconciler(mgr,
@@ -66,6 +67,7 @@ func SetupCloudSQLInstance(mgr ctrl.Manager, l logging.Logger, rl workqueue.Rate
 		managed.WithExternalConnecter(&cloudsqlConnector{kube: mgr.GetClient()}),
 		managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), managed.NewNameAsExternalName(mgr.GetClient()), &cloudsqlTagger{kube: mgr.GetClient()}),
 		managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+		managed.WithPollInterval(poll),
 		managed.WithLogger(l.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
 

--- a/pkg/controller/gcp.go
+++ b/pkg/controller/gcp.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -36,9 +38,8 @@ import (
 
 // Setup creates all GCP controllers with the supplied logger and adds them to
 // the supplied manager.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
-	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter) error{
-		config.Setup,
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
+	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, time.Duration) error{
 		cache.SetupCloudMemorystoreInstance,
 		compute.SetupGlobalAddress,
 		compute.SetupNetwork,
@@ -58,9 +59,9 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 		storage.SetupBucketPolicy,
 		storage.SetupBucketPolicyMember,
 	} {
-		if err := setup(mgr, l, rl); err != nil {
+		if err := setup(mgr, l, rl, poll); err != nil {
 			return err
 		}
 	}
-	return nil
+	return config.Setup(mgr, l, rl)
 }

--- a/pkg/controller/iam/serviceaccount.go
+++ b/pkg/controller/iam/serviceaccount.go
@@ -19,6 +19,7 @@ package iam
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	iamv1 "google.golang.org/api/iam/v1"
@@ -51,7 +52,7 @@ const (
 )
 
 // SetupServiceAccount adds a controller that reconciles ServiceAccounts.
-func SetupServiceAccount(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupServiceAccount(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.ServiceAccountGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -63,6 +64,7 @@ func SetupServiceAccount(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLi
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.ServiceAccountGroupVersionKind),
 			managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/iam/serviceaccountkey.go
+++ b/pkg/controller/iam/serviceaccountkey.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
@@ -59,7 +60,7 @@ const (
 )
 
 // SetupServiceAccountKey adds a controller that reconciles ServiceAccountKeys.
-func SetupServiceAccountKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupServiceAccountKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.ServiceAccountKeyGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -72,6 +73,7 @@ func SetupServiceAccountKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.Rat
 			resource.ManagedKind(v1alpha1.ServiceAccountKeyGroupVersionKind),
 			managed.WithInitializers(),
 			managed.WithExternalConnecter(&serviceAccountKeyServiceConnector{client: mgr.GetClient()}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/iam/serviceaccountpolicy.go
+++ b/pkg/controller/iam/serviceaccountpolicy.go
@@ -18,6 +18,7 @@ package iam
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	iamv1 "google.golang.org/api/iam/v1"
@@ -47,7 +48,7 @@ const (
 )
 
 // SetupServiceAccountPolicy adds a controller that reconciles ServiceAccountPolicys.
-func SetupServiceAccountPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupServiceAccountPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.ServiceAccountPolicyGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -60,6 +61,7 @@ func SetupServiceAccountPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.
 			resource.ManagedKind(v1alpha1.ServiceAccountPolicyGroupVersionKind),
 			managed.WithExternalConnecter(&serviceAccountPolicyConnecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/kms/cryptokey.go
+++ b/pkg/controller/kms/cryptokey.go
@@ -19,6 +19,7 @@ package kms
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -47,7 +48,7 @@ const (
 )
 
 // SetupCryptoKey adds a controller that reconciles CryptoKeys.
-func SetupCryptoKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupCryptoKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.CryptoKeyGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -60,6 +61,7 @@ func SetupCryptoKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter
 			resource.ManagedKind(v1alpha1.CryptoKeyGroupVersionKind),
 			managed.WithExternalConnecter(&cryptoKeyConnecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/kms/cryptokeypolicy.go
+++ b/pkg/controller/kms/cryptokeypolicy.go
@@ -18,6 +18,7 @@ package kms
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	kmsv1 "google.golang.org/api/cloudkms/v1"
@@ -46,7 +47,7 @@ const (
 )
 
 // SetupCryptoKeyPolicy adds a controller that reconciles CryptoKeyPolicys.
-func SetupCryptoKeyPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupCryptoKeyPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.CryptoKeyPolicyGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -59,6 +60,7 @@ func SetupCryptoKeyPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateL
 			resource.ManagedKind(v1alpha1.CryptoKeyPolicyGroupVersionKind),
 			managed.WithExternalConnecter(&cryptoKeyPolicyConnecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/kms/keyring.go
+++ b/pkg/controller/kms/keyring.go
@@ -19,6 +19,7 @@ package kms
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	kmsv1 "google.golang.org/api/cloudkms/v1"
@@ -50,7 +51,7 @@ const (
 )
 
 // SetupKeyRing adds a controller that reconciles KeyRings.
-func SetupKeyRing(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupKeyRing(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.KeyRingGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -62,6 +63,7 @@ func SetupKeyRing(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) 
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.KeyRingGroupVersionKind),
 			managed.WithExternalConnecter(&keyRingConnecter{client: mgr.GetClient()}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/pubsub/topic.go
+++ b/pkg/controller/pubsub/topic.go
@@ -18,6 +18,7 @@ package pubsub
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -51,7 +52,7 @@ const (
 )
 
 // SetupTopic adds a controller that reconciles Topics.
-func SetupTopic(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupTopic(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.TopicGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -63,6 +64,7 @@ func SetupTopic(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) er
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.TopicGroupVersionKind),
 			managed.WithExternalConnecter(&connector{client: mgr.GetClient()}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/servicenetworking/connection.go
+++ b/pkg/controller/servicenetworking/connection.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"time"
 
 	"github.com/pkg/errors"
 	compute "google.golang.org/api/compute/v1"
@@ -74,7 +75,7 @@ const (
 
 // SetupConnection adds a controller that reconciles Connection
 // managed resources.
-func SetupConnection(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupConnection(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.ConnectionGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -87,6 +88,7 @@ func SetupConnection(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 			managed.WithExternalConnecter(&connector{client: mgr.GetClient()}),
 			managed.WithConnectionPublishers(),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/storage/bucket.go
+++ b/pkg/controller/storage/bucket.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"context"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/google/go-cmp/cmp"
@@ -52,7 +53,7 @@ const (
 )
 
 // SetupBucket adds a controller that reconciles Buckets.
-func SetupBucket(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupBucket(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha3.BucketGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -64,6 +65,7 @@ func SetupBucket(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) e
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha3.BucketGroupVersionKind),
 			managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/storage/bucketpolicy.go
+++ b/pkg/controller/storage/bucketpolicy.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	"google.golang.org/api/storage/v1"
@@ -47,7 +48,7 @@ const (
 )
 
 // SetupBucketPolicy adds a controller that reconciles BucketPolicys.
-func SetupBucketPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupBucketPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.BucketPolicyGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -60,6 +61,7 @@ func SetupBucketPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimi
 			resource.ManagedKind(v1alpha1.BucketPolicyGroupVersionKind),
 			managed.WithExternalConnecter(&bucketPolicyConnecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/storage/bucketpolicymember.go
+++ b/pkg/controller/storage/bucketpolicymember.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	"google.golang.org/api/storage/v1"
@@ -44,7 +45,7 @@ const (
 )
 
 // SetupBucketPolicyMember adds a controller that reconciles BucketPolicyMembers.
-func SetupBucketPolicyMember(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupBucketPolicyMember(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.BucketPolicyMemberGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -57,6 +58,7 @@ func SetupBucketPolicyMember(mgr ctrl.Manager, l logging.Logger, rl workqueue.Ra
 			resource.ManagedKind(v1alpha1.BucketPolicyMemberGroupVersionKind),
 			managed.WithExternalConnecter(&bucketPolicyMemberConnecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds a `--poll-interval` flag to provider, which is passed to all controllers to set their polling interval in the reconciliation happy path.

*Note to reviewers: these changes are almost entirely find and replace.*

xref https://github.com/crossplane/crossplane-runtime/issues/253

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

See https://github.com/crossplane/provider-aws/pull/741 for testing steps.

[contribution process]: https://git.io/fj2m9
