### PR TITLE
Always convert nodepool image type to upper case

### DIFF
--- a/pkg/clients/nodepool/nodepool.go
+++ b/pkg/clients/nodepool/nodepool.go
@@ -85,7 +85,7 @@ func GenerateConfig(in *v1beta1.NodeConfig, pool *container.NodePool) { // nolin
 		pool.Config.BootDiskKmsKey = gcp.StringValue(in.BootDiskKmsKey)
 		pool.Config.DiskSizeGb = gcp.Int64Value(in.DiskSizeGb)
 		pool.Config.DiskType = gcp.StringValue(in.DiskType)
-		pool.Config.ImageType = gcp.StringValue(in.ImageType)
+		pool.Config.ImageType = strings.ToUpper(gcp.StringValue(in.ImageType))
 		pool.Config.Labels = in.Labels
 		pool.Config.LocalSsdCount = gcp.Int64Value(in.LocalSsdCount)
 		pool.Config.MachineType = gcp.StringValue(in.MachineType)


### PR DESCRIPTION
### Description of your changes

Nodepool resource could be created with both lower and upper case `spec.forProvider.config.imageType` but gcloud always returns upper case version which is considered as a configuration difference causing continuous upgrades.
This PR aims to fix this by always using the upper case version while generating the desired spec.

Fixes #361

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Using the manifests in #361, make sure that the casing in the image type field does not trigger an update.

[contribution process]: https://git.io/fj2m9
