### PR TITLE
Update available postgres versions

### DIFF
--- a/apis/database/v1beta1/cloudsql_instance_types.go
+++ b/apis/database/v1beta1/cloudsql_instance_types.go
@@ -76,7 +76,7 @@ type CloudSQLInstanceParameters struct {
 	// DatabaseVersion: The database engine type and version. The
 	// databaseVersion field can not be changed after instance creation.
 	// MySQL Second Generation instances: MYSQL_5_7 (default) or MYSQL_5_6.
-	// PostgreSQL instances: POSTGRES_9_6 (default) or POSTGRES_11 Beta.
+	// PostgreSQL instances: POSTGRES_9_6, POSTGRES_10, POSTGRES_11, POSTGRES_12, POSTGRES_13 (default)
 	// MySQL First Generation instances: MYSQL_5_6 (default) or MYSQL_5_5
 	// +immutable
 	// +optional

--- a/apis/database/v1beta1/cloudsql_instance_types.go
+++ b/apis/database/v1beta1/cloudsql_instance_types.go
@@ -76,7 +76,7 @@ type CloudSQLInstanceParameters struct {
 	// DatabaseVersion: The database engine type and version. The
 	// databaseVersion field can not be changed after instance creation.
 	// MySQL Second Generation instances: MYSQL_5_7 (default) or MYSQL_5_6.
-	// PostgreSQL instances: POSTGRES_9_6, POSTGRES_10, POSTGRES_11, POSTGRES_12, POSTGRES_13 (default)
+	// PostgreSQL instances: POSTGRES_9_6, POSTGRES_10, POSTGRES_11, POSTGRES_12, POSTGRES_13
 	// MySQL First Generation instances: MYSQL_5_6 (default) or MYSQL_5_5
 	// +immutable
 	// +optional

--- a/package/crds/database.gcp.crossplane.io_cloudsqlinstances.yaml
+++ b/package/crds/database.gcp.crossplane.io_cloudsqlinstances.yaml
@@ -73,9 +73,9 @@ spec:
                     description: 'DatabaseVersion: The database engine type and version.
                       The databaseVersion field can not be changed after instance
                       creation. MySQL Second Generation instances: MYSQL_5_7 (default)
-                      or MYSQL_5_6. PostgreSQL instances: POSTGRES_9_6 (default) or
-                      POSTGRES_11 Beta. MySQL First Generation instances: MYSQL_5_6
-                      (default) or MYSQL_5_5'
+                      or MYSQL_5_6. PostgreSQL instances: POSTGRES_9_6, POSTGRES_10,
+                      POSTGRES_11, POSTGRES_12, POSTGRES_13 (default). MySQL First Generation
+                      instances: MYSQL_5_6 (default) or MYSQL_5_5'
                     type: string
                   diskEncryptionConfiguration:
                     description: 'DiskEncryptionConfiguration: Disk encryption configuration


### PR DESCRIPTION
### Description of your changes
This change updates the list of available postgres versions to match Google documentation, adding 10, 12 and 13. Without this change only 9_6 and 11 are listed for postgres.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
The available versions were validated by leveraging the provider through Crossplane.

[contribution process]: https://git.io/fj2m9
