### PR TITLE
Validate private network for cloudsql is in expected format

### DIFF
--- a/apis/database/v1beta1/cloudsql_instance_types.go
+++ b/apis/database/v1beta1/cloudsql_instance_types.go
@@ -349,11 +349,12 @@ type IPConfiguration struct {
 
 	// PrivateNetwork: The resource link for the VPC network from which the
 	// Cloud SQL instance is accessible for private IP. For example,
-	// /projects/myProject/global/networks/default. This setting can be updated,
+	// projects/myProject/global/networks/default. This setting can be updated,
 	// but it cannot be removed after it is set. The Network must have an active
 	// Service Networking connection peering before resolution will proceed.
 	// https://cloud.google.com/vpc/docs/configure-private-services-access
 	// +optional
+	// +kubebuilder:validation:Pattern=^projects\/.+
 	PrivateNetwork *string `json:"privateNetwork,omitempty"`
 
 	// PrivateNetworkRef sets the PrivateNetwork field by resolving the resource

--- a/package/crds/database.gcp.crossplane.io_cloudsqlinstances.yaml
+++ b/package/crds/database.gcp.crossplane.io_cloudsqlinstances.yaml
@@ -287,11 +287,12 @@ spec:
                           privateNetwork:
                             description: 'PrivateNetwork: The resource link for the
                               VPC network from which the Cloud SQL instance is accessible
-                              for private IP. For example, /projects/myProject/global/networks/default.
+                              for private IP. For example, projects/myProject/global/networks/default.
                               This setting can be updated, but it cannot be removed
                               after it is set. The Network must have an active Service
                               Networking connection peering before resolution will
                               proceed. https://cloud.google.com/vpc/docs/configure-private-services-access'
+                            pattern: ^projects\/.+
                             type: string
                           privateNetworkRef:
                             description: PrivateNetworkRef sets the PrivateNetwork


### PR DESCRIPTION
### Description of your changes

Google Cloud API expects the resource link for the VPC network for [the CloudSQL private network field](https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/instances#IpConfiguration). However, it also accepts VPC name (e.g. "default") but looks like it internally converts it to resource link by assuming it is in the same project, (projects/[project]/global/networks/[name]). This is causing issues like #352 where users are not aware about the underlying problem.

This PR adds a pattern validation on CRD using kubebuilder marker (thanks @hasheddan for pointing that out). 

Fixes #352 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

1. Create a cloudsql instance in the expected format and verify it is created properly (and not getting periodic updates)
2. Create the following resource and verify that a proper error is reported:

```
apiVersion: database.gcp.crossplane.io/v1beta1
kind: CloudSQLInstance
metadata:
  name: sre-6-db-hasan-bug352-4
  namespace: crossplane
spec:
  deletionPolicy: "Orphan"
  forProvider:
    databaseVersion: POSTGRES_11
    region: europe-west1
    settings:
      ipConfiguration:
        ipv4Enabled: false
        privateNetwork: default
      tier: db-custom-1-3840
  writeConnectionSecretToRef:
    name: db-connection
    namespace: default
```

```
$ kubectl create -f cloudsql.yaml

The CloudSQLInstance "cloudsql-bug352" is invalid: spec.forProvider.settings.ipConfiguration.privateNetwork: Invalid value: "default": spec.forProvider.settings.ipConfiguration.privateNetwork in body should match '^projects\/.+'
```

[contribution process]: https://git.io/fj2m9
