### PR TITLE
Handle storage autoresize in cloudsql

### DIFF
--- a/apis/database/v1beta1/cloudsql_instance_types.go
+++ b/apis/database/v1beta1/cloudsql_instance_types.go
@@ -187,6 +187,10 @@ type Settings struct {
 	// StorageAutoResize: Configuration to increase storage size
 	// automatically. The default value is true. Not used for First
 	// Generation instances.
+	// Please note, if storage auto resize enabled, it won't be possible to
+	// decrease the size of the database using the DataDiskSizeGb field as it is
+	// not an allowed operation on GCP side. But you would still be able to
+	// increase it.
 	// +optional
 	StorageAutoResize *bool `json:"storageAutoResize,omitempty"`
 
@@ -243,6 +247,10 @@ type Settings struct {
 
 	// DataDiskSizeGb: The size of data disk, in GB. The data disk size
 	// minimum is 10GB. Not used for First Generation instances.
+	// Please note, if storage auto resize enabled, it won't be possible to
+	// decrease the size of the database using this field as it is
+	// not an allowed operation on GCP side. But you would still be able to
+	// increase it.
 	// +optional
 	DataDiskSizeGb *int64 `json:"dataDiskSizeGb,omitempty"`
 

--- a/examples/database/cloudsql.yaml
+++ b/examples/database/cloudsql.yaml
@@ -1,0 +1,16 @@
+apiVersion: database.gcp.crossplane.io/v1beta1
+kind: CloudSQLInstance
+metadata:
+  name: example-cloudsql-instance
+spec:
+  forProvider:
+    databaseVersion: POSTGRES_11
+    region: us-west2
+    settings:
+      tier: db-custom-1-3840
+      dataDiskSizeGb: 20
+  providerConfigRef:
+    name: example
+  writeConnectionSecretToRef:
+    name: example-cloudsql-connection-details
+    namespace: crossplane-system

--- a/package/crds/database.gcp.crossplane.io_cloudsqlinstances.yaml
+++ b/package/crds/database.gcp.crossplane.io_cloudsqlinstances.yaml
@@ -212,7 +212,10 @@ spec:
                       dataDiskSizeGb:
                         description: 'DataDiskSizeGb: The size of data disk, in GB.
                           The data disk size minimum is 10GB. Not used for First Generation
-                          instances.'
+                          instances. Please note, if storage auto resize enabled,
+                          it won''t be possible to decrease the size of the database
+                          using this field as it is not an allowed operation on GCP
+                          side. But you would still be able to increase it.'
                         format: int64
                         type: integer
                       dataDiskType:
@@ -374,7 +377,11 @@ spec:
                       storageAutoResize:
                         description: 'StorageAutoResize: Configuration to increase
                           storage size automatically. The default value is true. Not
-                          used for First Generation instances.'
+                          used for First Generation instances. Please note, if storage
+                          auto resize enabled, it won''t be possible to decrease the
+                          size of the database using the DataDiskSizeGb field as it
+                          is not an allowed operation on GCP side. But you would still
+                          be able to increase it.'
                         type: boolean
                       storageAutoResizeLimit:
                         description: 'StorageAutoResizeLimit: The maximum size to

--- a/pkg/clients/cloudsql/cloudsql.go
+++ b/pkg/clients/cloudsql/cloudsql.go
@@ -208,6 +208,13 @@ func LateInitializeSpec(spec *v1beta1.CloudSQLInstanceParameters, in sqladmin.Da
 		if spec.Settings.StorageAutoResize == nil {
 			spec.Settings.StorageAutoResize = in.Settings.StorageAutoResize
 		}
+		// If storage auto resize enabled, GCP does not allow setting a smaller
+		// size but allows increasing it. Here, we set desired size as observed
+		// if it is bigger than the current value which would allows us to get
+		// in sync with the actual value but still allow us to increase it.
+		if gcp.BoolValue(spec.Settings.StorageAutoResize) && gcp.Int64Value(spec.Settings.DataDiskSizeGb) < in.Settings.DataDiskSizeGb {
+			spec.Settings.DataDiskSizeGb = gcp.Int64Ptr(in.Settings.DataDiskSizeGb)
+		}
 		if len(spec.Settings.DatabaseFlags) == 0 && len(in.Settings.DatabaseFlags) != 0 {
 			spec.Settings.DatabaseFlags = make([]*v1beta1.DatabaseFlags, len(in.Settings.DatabaseFlags))
 			for i, val := range in.Settings.DatabaseFlags {

--- a/pkg/clients/cloudsql/cloudsql_test.go
+++ b/pkg/clients/cloudsql/cloudsql_test.go
@@ -306,6 +306,36 @@ func TestLateInitializeSpec(t *testing.T) {
 				p.GceZone = gcp.StringPtr("us-different-2")
 			})},
 		},
+		"AutoResizeUsesObserved": {
+			args: args{
+				params: params(func(p *v1beta1.CloudSQLInstanceParameters) {
+					p.Settings.StorageAutoResize = gcp.BoolPtr(true)
+					p.Settings.DataDiskSizeGb = gcp.Int64Ptr(20)
+				}),
+				db: db(func(db *sqladmin.DatabaseInstance) {
+					db.Settings.DataDiskSizeGb = 30
+				}),
+			},
+			want: want{params: params(func(p *v1beta1.CloudSQLInstanceParameters) {
+				p.Settings.StorageAutoResize = gcp.BoolPtr(true)
+				p.Settings.DataDiskSizeGb = gcp.Int64Ptr(30)
+			})},
+		},
+		"AutoResizeAllowsIncrease": {
+			args: args{
+				params: params(func(p *v1beta1.CloudSQLInstanceParameters) {
+					p.Settings.StorageAutoResize = gcp.BoolPtr(true)
+					p.Settings.DataDiskSizeGb = gcp.Int64Ptr(30)
+				}),
+				db: db(func(db *sqladmin.DatabaseInstance) {
+					db.Settings.DataDiskSizeGb = 20
+				}),
+			},
+			want: want{params: params(func(p *v1beta1.CloudSQLInstanceParameters) {
+				p.Settings.StorageAutoResize = gcp.BoolPtr(true)
+				p.Settings.DataDiskSizeGb = gcp.Int64Ptr(30)
+			})},
+		},
 		"AllFilledAlready": {
 			args: args{
 				params: params(),


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #371

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

1. Create db with 20Gb and autoresize enabled
2. Increase size to 30Gb from console
3. Verify resource CR updates spec with this value
4. Increase value from resource CR, verify it is reflected
5. Try to decrease, verify not possible.

Also see unit tests.

[contribution process]: https://git.io/fj2m9
