### PR TITLE
docs: Add a note on external-name annotation on bucket

### DIFF
--- a/examples/storage/bucket.yaml
+++ b/examples/storage/bucket.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     example: "true"
   annotations:
+    # Note that this will be the actual bucket name so it has to be globally unique/available.
     crossplane.io/external-name: crossplane-example-bucket
 spec:
   location: US


### PR DESCRIPTION
I stumbled upon this issue and it took my a while to figure out how the resolve the permission issue as the error is not very informative and actually misleading. 

I was having trouble creating a bucket that requires `storage.buckets.get` access to the Google Cloud Storage bucket  while my SA has `roles/storage.admin`  already (see below for more info).  

```
managed/bucket.storage.gcp.crossplane.io cannot get GCP bucket attributes: googleapi: Error 403: terry-test@a-test.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket., forbidden
```

```
gcloud projects add-iam-policy-binding --role=roles/storage.admin a-test --member "serviceAccount:terry-test@a-test.iam.gserviceaccount.com"
```

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
