### PR TITLE
Better member name format for roles/iam.workloadIdentityUser

### DIFF
--- a/examples/iam/serviceaccount/serviceaccountpolicy.yaml
+++ b/examples/iam/serviceaccount/serviceaccountpolicy.yaml
@@ -9,8 +9,9 @@ spec:
       name: perfect-test-sa
     policy:
       bindings:
+        # Ref: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
         - role: roles/iam.workloadIdentityUser
           members:
-            - serviceAccount:my-cool-project.svc.id.goog[vault-system/vault]
+            - serviceAccount:PROJECT_ID.svc.id.goog[K8S_NAMESPACE/KSA_NAME]
   providerConfigRef:
     name: gcp-provider


### PR DESCRIPTION
`vault-system/vault` is not used anywhere in this repo so better to use the format mentioned in the reference.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
