### PR TITLE
fix replica names for CloudSQLInstance

### DIFF
--- a/pkg/clients/cloudsql/cloudsql.go
+++ b/pkg/clients/cloudsql/cloudsql.go
@@ -188,7 +188,7 @@ func LateInitializeSpec(spec *v1beta1.CloudSQLInstanceParameters, in sqladmin.Da
 	spec.GceZone = gcp.LateInitializeString(spec.GceZone, in.GceZone)
 	spec.InstanceType = gcp.LateInitializeString(spec.InstanceType, in.InstanceType)
 	spec.MaxDiskSize = gcp.LateInitializeInt64(spec.MaxDiskSize, in.MaxDiskSize)
-	spec.ReplicaNames = gcp.LateInitializeStringSlice(spec.ReplicaNames, in.ReplicaNames)
+	spec.ReplicaNames = in.ReplicaNames
 	spec.SuspensionReason = gcp.LateInitializeStringSlice(spec.SuspensionReason, in.SuspensionReason)
 	if in.Settings != nil {
 		if spec.Settings.Tier == "" {

--- a/pkg/clients/cloudsql/cloudsql_test.go
+++ b/pkg/clients/cloudsql/cloudsql_test.go
@@ -323,6 +323,19 @@ func TestLateInitializeSpec(t *testing.T) {
 				p.Settings.DataDiskSizeGb = gcp.Int64Ptr(30)
 			})},
 		},
+		"ReplicaNamesSynced": {
+			args: args{
+				params: params(func(p *v1beta1.CloudSQLInstanceParameters) {
+					p.ReplicaNames = []string{"my-replica1"}
+				}),
+				db: db(func(db *sqladmin.DatabaseInstance) {
+					db.ReplicaNames = []string{"my-replica1", "my-replica2"}
+				}),
+			},
+			want: want{params: params(func(p *v1beta1.CloudSQLInstanceParameters) {
+				p.ReplicaNames = []string{"my-replica1", "my-replica2"}
+			})},
+		},
 		"AutoResizeAllowsIncrease": {
 			args: args{
 				params: params(func(p *v1beta1.CloudSQLInstanceParameters) {


### PR DESCRIPTION
Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
`LateInitializeStringSlice` does not correctly populate Slice replica names. It must be intialized  by `in.ReplicaNames` itself
Fixes  https://github.com/crossplane/provider-gcp/issues/392

I have:

- [ x] Read and followed Crossplane's [contribution process].
- [ x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I added unit test
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
