### PR TITLE
Support Workload Identity

### DIFF
--- a/apis/v1beta1/providerconfig_types.go
+++ b/apis/v1beta1/providerconfig_types.go
@@ -34,7 +34,7 @@ type ProviderConfigSpec struct {
 // ProviderCredentials required to authenticate.
 type ProviderCredentials struct {
 	// Source of the provider credentials.
-	// +kubebuilder:validation:Enum=None;Secret;Environment;Filesystem
+	// +kubebuilder:validation:Enum=None;Secret;InjectedIdentity;Environment;Filesystem
 	Source xpv1.CredentialsSource `json:"source"`
 
 	xpv1.CommonCredentialSelectors `json:",inline"`

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,0 +1,162 @@
+# Authenticating to Google Cloud APIs
+
+`provider-gcp` requires credentials to be provided in order to authenticate to
+the Google Cloud APIs. This can be done in one of the following ways:
+
+- Authenticating using a base-64 encoded service account key in a Kubernetes
+  `Secret`. This is described in detail [here](https://crossplane.io/docs/v1.6/getting-started/install-configure.html#get-gcp-account-keyfile).
+- Authenticating using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity).
+  This is described in the [section below](#authenticating-with-workload-identity).
+
+## Authenticating with Workload Identity
+
+*Note: This method is supported in `provider-gcp` v0.20.0 and later.*
+
+Using Workload Identity requires some additional setup.
+Many of the steps can also be found in the [documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).
+
+### Steps
+
+These steps assume you already have a running GKE cluster which has already
+enabled Workload Identity and has a sufficiently large node pool.
+
+Note that you can specify any valid strings to the variables below unless the
+variable is explicitly assigned.
+
+#### 1. Install Crossplane
+
+Install Crossplane from `stable` channel:
+
+```bash
+$ helm repo add crossplane-stable https://charts.crossplane.io/stable
+$ helm install crossplane --create-namespace --namespace crossplane-system crossplane-stable/crossplane
+```
+
+`provider-gcp` can be installed with either the [Crossplane CLI](https://crossplane.io/docs/v1.6/getting-started/install-configure.html#install-crossplane-cli)
+or a `Provider` resource as below:
+
+```console
+$ cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: ${PROVIDER_GCP}
+spec:
+  package: crossplane/provider-gcp:v${VERSION} # v0.20.0 or later
+  # Set a controllerConfigRef if you have a ControllerConfig:
+  # controllerConfigRef:
+  #   name: ${CONTROLLER_CONFIG}
+EOF
+```
+
+#### 2. Configure service accounts to use Workload Identity
+
+Create a GCP service account, which will be used for provisioning actual
+infrastructure in GCP, and grant IAM roles you need for accessing the Google
+Cloud APIs:
+
+```console
+$ gcloud iam service-accounts create ${GCP_SERVICE_ACCOUNT}
+$ gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+    --member "serviceAccount:${GCP_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com" \
+    --role ${ROLE} \
+    --project ${PROJECT_ID}
+```
+
+Get the name of your current `ProviderRevision` of this provider:
+
+```console
+$ REVISION=$(kubectl get providers.pkg.crossplane.io ${PROVIDER_GCP} -o jsonpath="{.status.currentRevision}")
+```
+
+Next, you'll configure IAM to use Workload Identity.
+In this step, you can choose one of the following options to configure service accounts:
+
+- [Option 1] Use a Kubernetes `ServiceAccount` managed by a provider's controller.
+- [Option 2] Use a Kubernetes `ServiceAccount` which you created and is specified to `.spec.serviceAccountName`
+  in a [`ControllerConfig`](https://doc.crds.dev/github.com/crossplane/crossplane/pkg.crossplane.io/ControllerConfig/v1alpha1@v1.6.2).
+
+##### 2.1. [Option 1] Use a controller-managed `ServiceAccount`
+
+Specify a Kubernetes `ServiceAccount` with the revision you got in the last
+step:
+
+```console
+$ KUBERNETES_SERVICE_ACCOUNT=${REVISION}
+```
+
+##### 2.1. [Option 2] Use a user-managed `ServiceAccount`
+
+Create a `ServiceAccount`, `ControllerConfig`, and `ClusterRoleBinding`:
+
+```console
+$ cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${KUBERNETES_SERVICE_ACCOUNT}
+  namespace: crossplane-system
+---
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: ${CONTROLLER_CONFIG}
+spec:
+  serviceAccountName: ${KUBERNETES_SERVICE_ACCOUNT}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane:provider:${PROVIDER_GCP}:system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane:provider:${REVISION}:system
+subjects:
+- kind: ServiceAccount
+  name: ${KUBERNETES_SERVICE_ACCOUNT}
+  namespace: crossplane-system
+EOF
+```
+
+#### 2.2. Allow the Kubernetes `ServiceAccount` to impersonate the GCP service account
+
+Grant `roles/iam.workloadIdentityUser` to the GCP service account:
+
+```console
+$ gcloud iam service-accounts add-iam-policy-binding \
+    ${GCP_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:${PROJECT_ID}.svc.id.goog[crossplane-system/${KUBERNETES_SERVICE_ACCOUNT}]" \
+    --project ${PROJECT_ID}
+```
+
+Annotate the `ServiceAccount` with the email address of the GCP service account:
+
+```console
+$ kubectl annotate serviceaccount ${KUBERNETES_SERVICE_ACCOUNT} \
+    iam.gke.io/gcp-service-account=${GCP_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
+    -n crossplane-system
+```
+
+### 3. Configure a `ProviderConfig`
+
+Create a `ProviderConfig` with `InjectedIdentity` in `.spec.credentials.source`:
+
+```console
+$ cat <<EOF | kubectl apply -f -
+apiVersion: gcp.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  projectID: $PROJECT_ID
+  credentials:
+    source: InjectedIdentity
+EOF
+```
+
+### 4. Next steps
+
+Now that you have configured `provider-gcp` with Workload Identity supported,
+you can [provision infrastructure](https://crossplane.io/docs/v1.6/getting-started/provision-infrastructure).

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -20,8 +20,20 @@ Many of the steps can also be found in the [documentation](https://cloud.google.
 These steps assume you already have a running GKE cluster which has already
 enabled Workload Identity and has a sufficiently large node pool.
 
-Note that you can specify any valid strings to the variables below unless the
-variable is explicitly assigned.
+#### 0. Prepare your variables
+
+In the following sections, you'll need to name your resources.
+Define the variables below with any names valid in Kubernetes or GCP so that you
+can smoothly set it up:
+
+```console
+$ PROJECT_ID=<YOUR_GCP_PROJECT_ID>                               # e.g.) acme-prod
+$ PROVIDER_GCP=<YOUR_PROVIDER_GCP_NAME>                          # e.g.) provider-gcp
+$ VERSION=<YOUR_PROVIDER_GCP_VERSION>                            # e.g.) 0.20.0
+$ GCP_SERVICE_ACCOUNT=<YOUR_CROSSPLANE_GCP_SERVICE_ACCOUNT_NAME> # e.g.) crossplane
+$ ROLE=<YOUR_ROLE_FOR_CROSSPLANE_GCP_SERVICE_ACCOUNT>            # e.g.) roles/cloudsql.admin
+$ CONTROLLER_CONFIG=<YOUR_CONTROLLER_CONFIG_NAME>                # e.g.) gcp-config (Optional)
+```
 
 #### 1. Install Crossplane
 
@@ -87,6 +99,12 @@ $ KUBERNETES_SERVICE_ACCOUNT=${REVISION}
 
 ##### 2.1. [Option 2] Use a user-managed `ServiceAccount`
 
+Name your Kubernetes `ServiceAccount`:
+
+```console
+$ KUBERNETES_SERVICE_ACCOUNT=<YOUR_KUBERNETES_SERVICE_ACCOUNT>
+```
+
 Create a `ServiceAccount`, `ControllerConfig`, and `ClusterRoleBinding`:
 
 ```console
@@ -150,7 +168,7 @@ kind: ProviderConfig
 metadata:
   name: default
 spec:
-  projectID: $PROJECT_ID
+  projectID: ${PROJECT_ID}
   credentials:
     source: InjectedIdentity
 EOF

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/imdario/mergo v0.3.12
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/pkg/errors v0.9.1
+	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	google.golang.org/api v0.52.0
 	google.golang.org/grpc v1.39.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -929,8 +929,9 @@ golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914 h1:3B43BWw0xEBsLZ/NO1VALz6fppU3481pik+2Ksv45z8=
 golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
+golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/package/crds/gcp.crossplane.io_providerconfigs.yaml
+++ b/package/crds/gcp.crossplane.io_providerconfigs.yaml
@@ -96,6 +96,7 @@ spec:
                     enum:
                     - None
                     - Secret
+                    - InjectedIdentity
                     - Environment
                     - Filesystem
                     type: string


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds support for Workload Identity, with which credentials no longer need to be present in Secrets.

If `InjectedIdentity` is specified, a token source for application default credentials by a GCP Service Account, which is specified in the `iam.gke.io/gcp-service-account` annotation of a provider's Kubernetes Service Account, is used for authentication.

Signed-off-by: micnncim <micnncim@gmail.com>

Fixes #173

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

Tested this in the following environment and process.

```console
$ kubectl version --short
Client Version: v1.20.7
Server Version: v1.20.12-gke.1500
```

```console
$ gcloud container clusters describe $CLUSTER --format="value(workloadIdentityConfig.workloadPool)"
$PROJECT_ID.svc.id.goog
```

```console
$ kubectl get deploy crossplane \
    -o jsonpath="{.spec.template.spec.containers[*].image}" \
    -n crossplane-system
crossplane/crossplane:v1.6.2
```

Created a `Provider` and `ProviderConfig` with `InjectedIdentity` and then created a `Topic` managed resource:

```console
$ cat <<EOF | kubectl apply -f -
apiVersion: pkg.crossplane.io/v1
kind: Provider
metadata:
  name: gcp-provider
spec:
  package: $PACKAGE # Use this version
---
apiVersion: gcp.crossplane.io/v1beta1
kind: ProviderConfig
metadata:
  name: default
spec:
  projectID: $PROJECT_ID
  credentials:
    source: InjectedIdentity
EOF

$ cat <<EOF | kubectl apply -f -
apiVersion: pubsub.gcp.crossplane.io/v1alpha1
kind: Topic
metadata:
  name: foo
spec:
  forProvider: {}
EOF
```

Note that Pods are emitting authentication errors until Workload Identity is configured:

```console
$ kubectl logs gcp-provider-f2edfcc2cd84-f68bc774f-7qscf
// ...
2022-02-06T20:07:06.014Z        DEBUG   provider-gcp    Cannot create external resource {"controller": "managed/topic.pubsub.gcp.crossplane.io", "request": "/foo", "uid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "version": "123456789", "external-name": "foo", "error": "cannot create Topic: googleapi: Error 403: User not authorized to perform this action., forbidden"}
```

Ensured the Service Account is specified in Deployment though it's obvious:

```console
$ kubectl get sa -o custom-columns=":metadata.name" | grep 'gcp-provider'
gcp-provider-xxxxxxxxxxxx
$ kubectl get deploy gcp-provider-xxxxxxxxxxxx \
    -o jsonpath="{.spec.template.spec.serviceAccountName}" \
gcp-provider-xxxxxxxxxxxx
```

Created a GCP Service Account and configured Workload Identity:

```console
$ gcloud iam service-accounts create crossplane
$ gcloud projects add-iam-policy-binding $PROJECT_ID \
    --member "serviceAccount:crossplane@$PROJECT_ID.iam.gserviceaccount.com" \
    --role roles/admin
$ gcloud iam service-accounts add-iam-policy-binding \
    crossplane@$PROJECT_ID.iam.gserviceaccount.com \
    --role roles/iam.workloadIdentityUser \
    --member "serviceAccount:$PROJECT_ID.svc.id.goog[crossplane-system/gcp-provider-xxxxxxxxxxxx]"
$ kubectl annotate sa gcp-provider-xxxxxxxxxxxx \
    iam.gke.io/gcp-service-account=crossplane@$PROJECT_ID.iam.gserviceaccount.com
```

Waited for a little while and then confirmed it was successfully created:

```console
$ gcloud pubsub topics describe foo
name: projects/$PROJECT_ID/topics/foo
```

Note that since Service Accounts managed by a controller are named the same as the current `ProviderRevision` and they are inconstant, it's necessary to fix a name for production use cases. https://github.com/crossplane/crossplane/pull/2880 proposes a change for this.
