### PR TITLE
Removal of comment for controllerConfigRef

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -55,9 +55,8 @@ metadata:
   name: ${PROVIDER_GCP}
 spec:
   package: crossplane/provider-gcp:v${VERSION} # v0.20.0 or later
-  # Set a controllerConfigRef if you have a ControllerConfig:
-  # controllerConfigRef:
-  #   name: ${CONTROLLER_CONFIG}
+  controllerConfigRef:
+    name: ${CONTROLLER_CONFIG}
 EOF
 ```
 


### PR DESCRIPTION
### Description of your changes
This removes a comment from the AUTHENTICATION for workloadIdentity, which causes confusion and results in a non-working example.

As the values are critical to the walkthrough, and we create the `controllerConfig` resource later in the guide, this makes no sense.

### How has this code been tested

This is a documentation change, noticed while deploying `crossplane-gcp` to a new cluster/environment.

[contribution process]: https://git.io/fj2m9
