### PR TITLE
Fix GKE ServiceAccount field in examples

### DIFF
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -142,7 +142,7 @@ echo_info "using crossplane version ${chart_version}"
 echo
 # we replace empty dir with our PVC so that the /cache dir in the kind node
 # container is exposed to the crossplane pod
-"${HELM3}" install crossplane --namespace crossplane-system crossplane-stable/crossplane --version ${chart_version} --wait --set packageCache.pvc=package-cache
+"${HELM3}" install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.6.4 --wait --set packageCache.pvc=package-cache
 
 # ----------- integration tests
 echo_step "--- INTEGRATION TESTS ---"

--- a/examples/gke/gke.yaml
+++ b/examples/gke/gke.yaml
@@ -6,7 +6,9 @@ spec:
   forProvider:
     initialClusterVersion: "1.20"
     location: us-west2
-    serviceAccount: sa-test
+    autoscaling:
+      autoprovisioningNodePoolDefaults:
+        serviceAccount: sa-test
     networkConfig:
       enableIntraNodeVisibility: true
     loggingService: logging.googleapis.com/kubernetes
@@ -33,6 +35,7 @@ spec:
     clusterRef:
       name: example-cluster
     config:
+      serviceAccount: sa-test
       machineType: n1-standard-1
       sandboxConfig:
         type: gvisor


### PR DESCRIPTION
### Description of your changes

Fixes #413

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Creating a `Cluster` and `NodePool` managed resources and checking that the ServiceAccount used by the `NodePool` was the one that was specified in the manifest


[contribution process]: https://git.io/fj2m9
