### PR TITLE
Use consistent group name for StoreConfig as ProviderConfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
       - name: Find the Go Build Cache
         id: go
         run: echo "::set-output name=cache::$(make go.cachedir)"
@@ -67,12 +72,10 @@ jobs:
       - name: Vendor Dependencies
         run: make vendor vendor.check
 
-      # This action uses its own setup-go, which always seems to use the latest
-      # stable version of Go. We could run 'make lint' to ensure our desired Go
-      # version, but we prefer this action because it leaves 'annotations' (i.e.
-      # it comments on PRs to point out linter violations).
+      # We could run 'make lint' but we prefer this action because it leaves
+      # 'annotations' (i.e. it comments on PRs to point out linter violations).
       - name: Lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: ${{ env.GOLANGCI_VERSION }}
 

--- a/apis/v1alpha1/doc.go
+++ b/apis/v1alpha1/doc.go
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Package v1alpha1 contains the core resources of the Google Cloud Platform.
 // +kubebuilder:object:generate=true
-// +groupName=gcp.secrets.crossplane.io
+// +groupName=gcp.crossplane.io
 // +versionName=v1alpha1
 package v1alpha1

--- a/apis/v1alpha1/register.go
+++ b/apis/v1alpha1/register.go
@@ -25,7 +25,7 @@ import (
 
 // Package type metadata.
 const (
-	Group   = "gcp.secrets.crossplane.io"
+	Group   = "gcp.crossplane.io"
 	Version = "v1alpha1"
 )
 

--- a/examples/storeconfig/kubernetes.yaml
+++ b/examples/storeconfig/kubernetes.yaml
@@ -1,4 +1,4 @@
-apiVersion: gcp.secrets.crossplane.io/v1alpha1
+apiVersion: gcp.crossplane.io/v1alpha1
 kind: StoreConfig
 metadata:
   name: default

--- a/examples/storeconfig/vault.yaml
+++ b/examples/storeconfig/vault.yaml
@@ -1,4 +1,4 @@
-apiVersion: gcp.secrets.crossplane.io/v1alpha1
+apiVersion: gcp.crossplane.io/v1alpha1
 kind: StoreConfig
 metadata:
   name: vault

--- a/package/crds/gcp.crossplane.io_storeconfigs.yaml
+++ b/package/crds/gcp.crossplane.io_storeconfigs.yaml
@@ -5,9 +5,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
-  name: storeconfigs.gcp.secrets.crossplane.io
+  name: storeconfigs.gcp.crossplane.io
 spec:
-  group: gcp.secrets.crossplane.io
+  group: gcp.crossplane.io
   names:
     categories:
     - crossplane


### PR DESCRIPTION
### Description of your changes

This PR changes the group name for `StoreConfig` from `gcp.secrets.crossplane.io` to `gcp.crossplane.io` to be consistent with  `ProviderConfig`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

By following [the updated guide](https://github.com/crossplane/crossplane/pull/3021).

[contribution process]: https://git.io/fj2m9
